### PR TITLE
Check if GPS is connected when exiting and close connection if it is.

### DIFF
--- a/MetaScanner/UI/Forms/frmMain.cs
+++ b/MetaScanner/UI/Forms/frmMain.cs
@@ -140,6 +140,13 @@ namespace inSSIDer.UI.Forms
             {
                 _scanner.StopScanning();
             }
+
+            if (_scanner.GpsControl.Enabled)
+            {
+                _scanner.GpsControl.Stop();
+                _scanner.Logger.Stop();
+                _gpsStatTimer.Stop();
+            }
             scannerView.Dispose();
             _scanner.Dispose();
             SettingsMgr.SaveScannerViewSettings(scannerView);


### PR DESCRIPTION
Fixes issue where connection is not closed when exiting preventing other programs from using the COM port.
